### PR TITLE
Corregir bug si idioma no es el español

### DIFF
--- a/pelisalacarta/channels/pordede.py
+++ b/pelisalacarta/channels/pordede.py
@@ -561,7 +561,8 @@ def play(item):
 
     data = scrapertools.cache_page(item.url,post="_s="+item.extra.split("|")[0],headers=headers)
     logger.info("data="+data)
-    url = scrapertools.find_single_match(data,'<a href="([^"]+)" target="_blank"><button>Visitar enlace</button>')
+    #url = scrapertools.find_single_match(data,'<a href="([^"]+)" target="_blank"><button>Visitar enlace</button>')
+    url = scrapertools.find_single_match(data,'<p class="links">\s+<a href="([^"]+)" target="_blank"')
     url = urlparse.urljoin(item.url,url)
 
     headers = DEFAULT_HEADERS[:]


### PR DESCRIPTION
Evitar buscar el enlace con el texto "Visitar enlace" para que funcione igualmente si el usuario de pordede no lo tiene en español.
